### PR TITLE
Update nmrih_russian.txt

### DIFF
--- a/nmrih/resource/nmrih_russian.txt
+++ b/nmrih/resource/nmrih_russian.txt
@@ -139,7 +139,7 @@
 
 "PlayerAlive"				"Состояние"
 "PlayerAlive_Alive"			"В живых"
-"PlayerAlive_Dead"			"Усопший"
+"PlayerAlive_Dead"			"Мёртв"
 "PlayerAlive_Extracted"			"Спасён"
 "PlayerRespawns"			"Возрождения"
 


### PR DESCRIPTION
очень специфическое слово "усопший", всегда было "мёртв", лучше его и оставить